### PR TITLE
[strict-modes] Support for strict and non-strict schemas

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ inherit_gem:
 
 AllCops:
   TargetRubyVersion: 2.7.1
+  NewCops: enable
   Include:
     - lib/**/*.rb
     - spec/**/*.rb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 # [Unreleased]
 ### Added
 - Support for *strict* and *non-strict* schemas;
+  - `strict!` DSL directive marks your schema as a strict schema (your hash can not have extra keys);
+  - `non_strict!` DSL directive marks your schema as non-strict schema (your hash can have extra keys);
+  - use `strict!` in any schema's context place to mark your current schema context as a strict;
+  - use `non_strict` in any schema's context place to mark your current schema context as a strict;
+  - use `schema(:strict)` to globally define strict schema (default behavior);
+  - use `schema(:non_strict)` to globally define non-strict schema;
+  - nested schemas inherits strict behavior from outer schemas;
+  - root schema is `:strict` by default;
+  - schema reopening without mode attribute does not change original schema mode
+    (you should manually pass a mode attribute to redefine already defined schema mode);
 
 # [0.2.0] - 2020-11-09
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+# [Unreleased]
+### Added
+- Support for *strict* and *non-strict* schemas;
+
 # [0.2.0] - 2020-11-09
 ### Added
 - `#errors` now includes `#extra_keys` too (`:extra_key` error code for each extra key);

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ require 'smart_core/schema'
 - strict modes and strict behavior: `strict!`, `non_strict!`, `schema(:strict)`, `schema(:non_strict)`;
 - `:strict` is used by default (in first `schema` invokation);
 - you can make non-strict inner schemas inside strict schemas (and vise-versa);
-- inner schemas inherits it's mode from their's outer schema (and can have own mode too);
+- inner schemas inherits their's mode from their's nearest outer schema (and can have own mode too);
 
 ```ruby
 class MySchema < SmartCore::Schema

--- a/README.md
+++ b/README.md
@@ -34,11 +34,26 @@ require 'smart_core/schema'
 - nested definitions: `do ... end`;
 - supported types: see `smart_types` gem;
 - strict modes and strict behavior: `strict!`, `non_strict!`, `schema(:strict)`, `schema(:non_strict)`;
+  - `:strict` is used by default (in first `schema` invokation);
+  - you can make non-strict inner schemas in strict schemas;
+  - inner schemas inherits it's mode from their's outer schema;
+  - in code:
+    ```ruby
+    schema(:strict) # for strict schemas
+    schema(:non_strict) # for non-strict schemas
+
+    strict! # inside schema definition
+    non_strict! # inside schema definition
+    ```
 
 ```ruby
 class MySchema < SmartCore::Schema
   # you can mark strict mode in root schema here:
+  #
   # non_strict!
+  #
+  # -- or --
+  #
   # strict!
 
   schema do # or here with `schema(:strict)` (default in first time) or `schema(:non_strict)`

--- a/README.md
+++ b/README.md
@@ -156,7 +156,8 @@ Possible errors:
 ## Roadmap
 
 - **(0.x.0)** - value-validation layer;
-- **(0.3.0)** - error messages (that are consistent with error codes), with a support for error-code-auto-mappings for error messages via explicit hashes or via file (yaml, json and other formats);
+- **(0.x.0)** - error messages (that are consistent with error codes), with a support for error-code-auto-mappings for error messages via explicit hashes or via file (yaml, json and other formats);
+- **(0.3.0)** - spread keys in validation result;
 - **(0.4.0)** - schema inheritance;
 - **(0.4.0)** - schema composition (`required(:key).schema(SchemaClass)`) (`compose_with(AnotherSchema)`);
 - **(0.4.0)** - dependable schema checking (sample: if one key exist (or not) we should check another (or not), and vice verca) (mb `if(:_key_)` rule);

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ require 'smart_core/schema'
   - use `schema(:non_strict)` to globally define non-strict schema;
   - nested schemas inherits strict behavior from outer schemas;
   - root schema is `:strict` by default;
+  - schema reopening without mode attribute does not change original schema mode
+    (you should manually pass a mode attribute to redefine already defined schema mode);
 
 ```ruby
 class MySchema < SmartCore::Schema
@@ -49,7 +51,7 @@ class MySchema < SmartCore::Schema
   # non_strict!
   # strict!
 
-  schema do # (or here) (the smae as `schema(:strict)`)
+  schema do
     required(:key) do
       # inherits `:strict`
       optional(:data).type(:string).filled

--- a/README.md
+++ b/README.md
@@ -34,17 +34,9 @@ require 'smart_core/schema'
 - nested definitions: `do ... end`;
 - supported types: see `smart_types` gem;
 - strict modes and strict behavior: `strict!`, `non_strict!`, `schema(:strict)`, `schema(:non_strict)`;
-  - `:strict` is used by default (in first `schema` invokation);
-  - you can make non-strict inner schemas in strict schemas;
-  - inner schemas inherits it's mode from their's outer schema;
-  - in code:
-    ```ruby
-    schema(:strict) # for strict schemas
-    schema(:non_strict) # for non-strict schemas
-
-    strict! # inside schema definition
-    non_strict! # inside schema definition
-    ```
+- `:strict` is used by default (in first `schema` invokation);
+- you can make non-strict inner schemas inside strict schemas (and vise-versa);
+- inner schemas inherits it's mode from their's outer schema (and can have own mode too);
 
 ```ruby
 class MySchema < SmartCore::Schema

--- a/README.md
+++ b/README.md
@@ -89,11 +89,11 @@ class MySchema < SmartCore::Schema
   #   non_strict!
   # end
   #
-  # -- and --
+  # -- and (redefine nested schema behavior) --
   #
   # schema do
   #   optional(:another_nested) do
-  #     strict!
+  #     strict! # change from :non_strict to :strict
   #   end
   # end
 end

--- a/README.md
+++ b/README.md
@@ -131,9 +131,11 @@ result = MySchema.new.validate(
 #  #<SmartCore::Schema::Result:0x00007ffcd8926990
 #  @errors={"key.data"=>[:non_filled], "key.value"=>[:invalid_type], "key.nested"=>[:required_key_not_found], "another_key"=>[:non_filled], "third_key"=>[:extra_key]},
 #  @extra_keys=#<Set: {"third_key"}>,
+#  @spread_keys=#<Set: {}>,
 #  @source={:key=>{:data=>nil, :value=>"1", :name=>"D@iVeR"}, :another_key=>nil, :third_key=>"test"}>
 
 result.success? # => false
+result.spread_keys # => <Set: {}> (this feature is coming soon; returns spread keys of non-strict schemas)
 result.extra_keys # => <Set: {"third_key"}>
 result.errors # =>
 {

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Provides convenient and concise DSL to define complex schemas in easiest way and public validation interface to achieve a comfortable work with detailed validation result.
 
-Supports nested structures, type validation (via `smart_types`), required- and optional- schema keys, schema value presence validation, schema inheritance (soon), schema extending (soon) and schema composition (soon).
+Supports nested structures, type validation (via `smart_types`), required- and optional- schema keys, *strict* and *non-strict* schemas, schema value presence validation, schema inheritance (soon), schema extending (soon) and schema composition (soon).
 
 Works in predicate style and in OOP/Monadic result object style. Enjoy :)
 
@@ -149,7 +149,7 @@ Possible errors:
 
 - **(0.x.0)** - value-validation layer;
 - **(0.x.0)** - error messages (that are consistent with error codes), with a support for error-code-auto-mappings for error messages via explicit hashes or via file (yaml, json and other formats);
-- **(0.3.0)** - spread keys in validation result;
+- **(0.3.0)** - spread keys of strict schemas in validation result;
 - **(0.4.0)** - schema inheritance;
 - **(0.4.0)** - schema composition (`required(:key).schema(SchemaClass)`) (`compose_with(AnotherSchema)`);
 - **(0.4.0)** - dependable schema checking (sample: if one key exist (or not) we should check another (or not), and vice verca) (mb `if(:_key_)` rule);

--- a/README.md
+++ b/README.md
@@ -33,25 +33,15 @@ require 'smart_core/schema'
 - `nil` control: `filled`;
 - nested definitions: `do ... end`;
 - supported types: see `smart_types` gem;
-- strict modes and strict behavior:
-  - `strict!` DSL directive marks your schema as a strict schema (your hash can not have extra keys);
-  - `non_strict!` DSL directive marks your schema as non-strict schema (your hash can have extra keys);
-  - use `strict!` in any schema's context place to mark your current schema context as a strict;
-  - use `non_strict` in any schema's context place to mark your current schema context as a strict;
-  - use `schema(:strict)` to globally define strict schema (default behavior);
-  - use `schema(:non_strict)` to globally define non-strict schema;
-  - nested schemas inherits strict behavior from outer schemas;
-  - root schema is `:strict` by default;
-  - schema reopening without mode attribute does not change original schema mode
-    (you should manually pass a mode attribute to redefine already defined schema mode);
+- strict modes and strict behavior: `strict!`, `non_strict!`, `schema(:strict)`, `schema(:non_strict)`;
 
 ```ruby
 class MySchema < SmartCore::Schema
-  # you can mark root schema here:
+  # you can mark strict mode in root schema here:
   # non_strict!
   # strict!
 
-  schema do # or here with `schema(:strict)` (default in first invocation) or `schema(:non_strict)`
+  schema do # or here with `schema(:strict)` (default in first time) or `schema(:non_strict)`
     required(:key) do
       # inherits `:strict`
       optional(:data).type(:string).filled
@@ -64,7 +54,7 @@ class MySchema < SmartCore::Schema
       end
 
       optional(:another_nested) do
-        non_strict! # marks current nested schema as :non_strict
+        non_strict! # marks current nested schema as `:non_strict`
       end
     end
 
@@ -88,8 +78,8 @@ class MySchema < SmartCore::Schema
   # schema do
   #   non_strict!
   # end
-  #
-  # -- and (redefine nested schema behavior) --
+  
+  # you can redefine nested schema behavior:
   #
   # schema do
   #   optional(:another_nested) do
@@ -131,11 +121,11 @@ result = MySchema.new.validate(
 #  #<SmartCore::Schema::Result:0x00007ffcd8926990
 #  @errors={"key.data"=>[:non_filled], "key.value"=>[:invalid_type], "key.nested"=>[:required_key_not_found], "another_key"=>[:non_filled], "third_key"=>[:extra_key]},
 #  @extra_keys=#<Set: {"third_key"}>,
-#  @spread_keys=#<Set: {}>,
+#  @spread_keys=#<Set: {}>, (coming soon (spread keys of non-strict schemas))
 #  @source={:key=>{:data=>nil, :value=>"1", :name=>"D@iVeR"}, :another_key=>nil, :third_key=>"test"}>
 
 result.success? # => false
-result.spread_keys # => <Set: {}> (this feature is coming soon; returns spread keys of non-strict schemas)
+result.spread_keys # => <Set: {}> (coming soon (spread keys of non-strict schemas))
 result.extra_keys # => <Set: {"third_key"}>
 result.errors # =>
 {

--- a/README.md
+++ b/README.md
@@ -33,17 +33,36 @@ require 'smart_core/schema'
 - `nil` control: `filled`;
 - nested definitions: `do ... end`;
 - supported types: see `smart_types` gem;
+- strict modes and strict behavior:
+  - `strict!` DSL directive marks your schema as a strict schema (your hash can not have extra keys);
+  - `non_strict!` DSL directive marks your schema as non-strict schema (your hash can have extra keys);
+  - use `strict!` in any schema's context place to mark your current schema context as a strict;
+  - use `non_strict` in any schema's context place to mark your current schema context as a strict;
+  - use `schema(:strict)` to globally define strict schema (default behavior);
+  - use `schema(:non_strict)` to globally define non-strict schema;
+  - nested schemas inherits strict behavior from outer schemas;
+  - root schema is `:strict` by default;
 
 ```ruby
 class MySchema < SmartCore::Schema
-  schema do
+  # you can mark root schema here:
+  # non_strict!
+  # strict!
+
+  schema do # (or here) (the smae as `schema(:strict)`)
     required(:key) do
+      # inherits `:strict`
       optional(:data).type(:string).filled
       optional(:value).type(:numeric)
       required(:name).type(:string)
 
       required(:nested) do
+        # inherits `:strict`
         optional(:version).filled
+      end
+
+      optional(:another_nested) do
+        non_strict! # and here
       end
     end
 
@@ -116,7 +135,6 @@ Possible errors:
 
 - **(0.x.0)** - value-validation layer;
 - **(0.3.0)** - error messages (that are consistent with error codes), with a support for error-code-auto-mappings for error messages via explicit hashes or via file (yaml, json and other formats);
-- **(0.3.0)** - optional support for non-strict schemas (that allows extra keys);
 - **(0.4.0)** - schema inheritance;
 - **(0.4.0)** - schema composition (`required(:key).schema(SchemaClass)`) (`compose_with(AnotherSchema)`);
 - **(0.4.0)** - dependable schema checking (sample: if one key exist (or not) we should check another (or not), and vice verca) (mb `if(:_key_)` rule);

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ class MySchema < SmartCore::Schema
   # non_strict!
   # strict!
 
-  schema do # or here
+  schema do # or here with `schema(:strict)` (default in first invocation) or `schema(:non_strict)`
     required(:key) do
       # inherits `:strict`
       optional(:data).type(:string).filled
@@ -64,7 +64,7 @@ class MySchema < SmartCore::Schema
       end
 
       optional(:another_nested) do
-        non_strict! # marks current schema as :non_strict
+        non_strict! # marks current nested schema as :non_strict
       end
     end
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ class MySchema < SmartCore::Schema
   # schema do
   #   non_strict!
   # end
+  #
+  # -- or --
+  #
+  # non_strict!
   
   # you can redefine nested schema behavior:
   #
@@ -156,7 +160,7 @@ Possible errors:
 
 - **(0.x.0)** - value-validation layer;
 - **(0.x.0)** - error messages (that are consistent with error codes), with a support for error-code-auto-mappings for error messages via explicit hashes or via file (yaml, json and other formats);
-- **(0.3.0)** - spread keys of strict schemas in validation result;
+- **(0.3.0)** - spread keys of non-strict schemas in validation result;
 - **(0.4.0)** - schema inheritance;
 - **(0.4.0)** - schema composition (`required(:key).schema(SchemaClass)`) (`compose_with(AnotherSchema)`);
 - **(0.4.0)** - dependable schema checking (sample: if one key exist (or not) we should check another (or not), and vice verca) (mb `if(:_key_)` rule);

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ class MySchema < SmartCore::Schema
   # non_strict!
   # strict!
 
-  schema do
+  schema do # or here
     required(:key) do
       # inherits `:strict`
       optional(:data).type(:string).filled
@@ -64,7 +64,7 @@ class MySchema < SmartCore::Schema
       end
 
       optional(:another_nested) do
-        non_strict! # and here
+        non_strict! # marks current schema as :non_strict
       end
     end
 
@@ -75,6 +75,26 @@ class MySchema < SmartCore::Schema
   #
   # schema do
   #   required(:third_key).filled.type(:string)
+  # end
+
+  # you can redefine strict behavior of already defined schema:
+  #
+  # schema(:non_strict) do
+  #   ...
+  # end
+  #
+  # -- or --
+  #
+  # schema do
+  #   non_strict!
+  # end
+  #
+  # -- and --
+  #
+  # schema do
+  #   optional(:another_nested) do
+  #     strict!
+  #   end
   # end
 end
 ```

--- a/lib/smart_core/schema/checker.rb
+++ b/lib/smart_core/schema/checker.rb
@@ -2,7 +2,7 @@
 
 # @api private
 # @since 0.1.0
-# @version 0.2.0
+# @version 0.3.0
 class SmartCore::Schema::Checker
   require_relative 'checker/verifiable_hash'
   require_relative 'checker/rules'
@@ -36,7 +36,7 @@ class SmartCore::Schema::Checker
   # @return [void]
   #
   # @api private
-  # @since 0.2.0
+  # @since 0.3.0
   def invoke_in_pipe(&checker_invokations)
     thread_safe { instance_eval(&checker_invokations) }
   end
@@ -45,7 +45,7 @@ class SmartCore::Schema::Checker
   # @return [void]
   #
   # @api private
-  # @since 0.2.0
+  # @since 0.3.0
   def set_strict_mode(strict_mode)
     thread_safe { apply_strict_mode(strict_mode) }
   end
@@ -93,7 +93,7 @@ class SmartCore::Schema::Checker
   # @return [void]
   #
   # @api private
-  # @since 0.2.0
+  # @since 0.3.0
   def apply_strict_mode(strict_mode)
     Reconciler::Constructor.set_strict_mode(reconciler, strict_mode)
   end

--- a/lib/smart_core/schema/checker.rb
+++ b/lib/smart_core/schema/checker.rb
@@ -2,6 +2,7 @@
 
 # @api private
 # @since 0.1.0
+# @version 0.2.0
 class SmartCore::Schema::Checker
   require_relative 'checker/verifiable_hash'
   require_relative 'checker/rules'
@@ -29,6 +30,24 @@ class SmartCore::Schema::Checker
 
       reconciler.__match!(VerifiableHash.new(verifiable_hash)).complete!
     end
+  end
+
+  # @param checker_invokations [Block]
+  # @return [void]
+  #
+  # @api private
+  # @since 0.2.0
+  def invoke_in_pipe(&checker_invokations)
+    thread_safe { instance_eval(&checker_invokations) }
+  end
+
+  # @param strict_mode [NilClass, String, Symbol]
+  # @return [void]
+  #
+  # @api private
+  # @since 0.2.0
+  def set_strict_mode(strict_mode)
+    thread_safe { apply_strict_mode(strict_mode) }
   end
 
   # @param definitions [Block]
@@ -68,6 +87,15 @@ class SmartCore::Schema::Checker
     ERROR_MESSAGE
 
     Reconciler::Constructor.append_definitions(reconciler, &definitions)
+  end
+
+  # @param strict_mode [NilClass, String, Symbol]
+  # @return [void]
+  #
+  # @api private
+  # @since 0.2.0
+  def apply_strict_mode(strict_mode)
+    Reconciler::Constructor.set_strict_mode(reconciler, strict_mode)
   end
 
   # @param block [Block]

--- a/lib/smart_core/schema/checker/reconciler.rb
+++ b/lib/smart_core/schema/checker/reconciler.rb
@@ -2,6 +2,7 @@
 
 # @api private
 # @since 0.1.0
+# @version 0.2.0
 class SmartCore::Schema::Checker::Reconciler
   require_relative 'reconciler/constructor'
   require_relative 'reconciler/matcher'
@@ -12,6 +13,7 @@ class SmartCore::Schema::Checker::Reconciler
   # @since 0.1.0
   def initialize
     @rules = SmartCore::Schema::Checker::Rules.new
+    @strict = Constructor::DEFAULT_STRICT_BEHAVIOR
     @lock = SmartCore::Engine::Lock.new
   end
 
@@ -64,6 +66,23 @@ class SmartCore::Schema::Checker::Reconciler
       rule = SmartCore::Schema::Checker::Rules::Optional.new(schema_key, &nested_definitions)
       rule.tap { rules[rule.schema_key] = rule }
     end
+  end
+
+  # @param is_strict [Boolean]
+  # @return [void]
+  #
+  # @api public
+  # @since 0.2.0
+  def strict!(is_strict = Constructor::DEFAULT_STRICT_BEHAVIOR)
+    thread_safe { @strict = is_strict }
+  end
+
+  # @return [void]
+  #
+  # @api public
+  # @since 0.2.0
+  def non_strict!
+    thread_safe { strict!(false) }
   end
 
   private

--- a/lib/smart_core/schema/checker/reconciler.rb
+++ b/lib/smart_core/schema/checker/reconciler.rb
@@ -11,6 +11,7 @@ class SmartCore::Schema::Checker::Reconciler
   #
   # @api private
   # @since 0.1.0
+  # @version 0.2.0
   def initialize
     @rules = SmartCore::Schema::Checker::Rules.new
     @strict = Constructor::DEFAULT_STRICT_BEHAVIOR

--- a/lib/smart_core/schema/checker/reconciler.rb
+++ b/lib/smart_core/schema/checker/reconciler.rb
@@ -11,7 +11,7 @@ class SmartCore::Schema::Checker::Reconciler
   #
   # @api private
   # @since 0.1.0
-  # @version 0.2.0
+  # @version 0.3.0
   def initialize
     @rules = SmartCore::Schema::Checker::Rules.new
     @strict = Constructor::DEFAULT_STRICT_BEHAVIOR

--- a/lib/smart_core/schema/checker/reconciler.rb
+++ b/lib/smart_core/schema/checker/reconciler.rb
@@ -2,7 +2,7 @@
 
 # @api private
 # @since 0.1.0
-# @version 0.2.0
+# @version 0.3.0
 class SmartCore::Schema::Checker::Reconciler
   require_relative 'reconciler/constructor'
   require_relative 'reconciler/matcher'
@@ -57,9 +57,10 @@ class SmartCore::Schema::Checker::Reconciler
   #
   # @api public
   # @since 0.1.0
+  # @version 0.3.0
   def required(schema_key, &nested_definitions)
     thread_safe do
-      rule = SmartCore::Schema::Checker::Rules::Required.new(schema_key, &nested_definitions)
+      rule = SmartCore::Schema::Checker::Rules::Required.new(self, schema_key, &nested_definitions)
       rule.tap { rules[rule.schema_key] = rule }
     end
   end
@@ -70,9 +71,10 @@ class SmartCore::Schema::Checker::Reconciler
   #
   # @api public
   # @since 0.1.0
+  # @version 0.3.0
   def optional(schema_key, &nested_definitions)
     thread_safe do
-      rule = SmartCore::Schema::Checker::Rules::Optional.new(schema_key, &nested_definitions)
+      rule = SmartCore::Schema::Checker::Rules::Optional.new(self, schema_key, &nested_definitions)
       rule.tap { rules[rule.schema_key] = rule }
     end
   end
@@ -81,7 +83,7 @@ class SmartCore::Schema::Checker::Reconciler
   # @return [void]
   #
   # @api public
-  # @since 0.2.0
+  # @since 0.3.0
   def strict!(is_strict = Constructor::DEFAULT_STRICT_BEHAVIOR)
     thread_safe { @strict = is_strict }
   end
@@ -89,7 +91,7 @@ class SmartCore::Schema::Checker::Reconciler
   # @return [void]
   #
   # @api public
-  # @since 0.2.0
+  # @since 0.3.0
   def non_strict!
     thread_safe { strict!(Constructor::STRICT_MODES[:non_strict]) }
   end

--- a/lib/smart_core/schema/checker/reconciler.rb
+++ b/lib/smart_core/schema/checker/reconciler.rb
@@ -43,6 +43,14 @@ class SmartCore::Schema::Checker::Reconciler
     thread_safe { rules }
   end
 
+  # @return [Boolean]
+  #
+  # @api private
+  # @since 0.3.0
+  def __strict?
+    thread_safe { @strict }
+  end
+
   # @param schema_key [String, Symbol]
   # @param nested_definitions [Block]
   # @return [SmartCore::Schema::Checker::Rules::Required]

--- a/lib/smart_core/schema/checker/reconciler.rb
+++ b/lib/smart_core/schema/checker/reconciler.rb
@@ -82,7 +82,7 @@ class SmartCore::Schema::Checker::Reconciler
   # @api public
   # @since 0.2.0
   def non_strict!
-    thread_safe { strict!(false) }
+    thread_safe { strict!(Constructor::STRICT_MODES[:non_strict]) }
   end
 
   private

--- a/lib/smart_core/schema/checker/reconciler/constructor.rb
+++ b/lib/smart_core/schema/checker/reconciler/constructor.rb
@@ -2,7 +2,20 @@
 
 # @api private
 # @since 0.1.0
+# @version 0.2.0
 module SmartCore::Schema::Checker::Reconciler::Constructor
+  # @return [Hash<String,Boolean>]
+  #
+  # @api private
+  # @since 0.2.0
+  STRICT_MODES = { strict: true, 'strict' => true, non_strict: false, 'non_strict' => true }.freeze
+
+  # @return [Boolean]
+  #
+  # @pai private
+  # @since 0.2.0
+  DEFAULT_STRICT_BEHAVIOR = STRICT_MODES[:strict] # NOTE: means `strict by default`
+
   class << self
     # @param reconciler [SmartCore::Schema::Checker::Reconciler]
     # @param definitions [Proc]
@@ -12,6 +25,25 @@ module SmartCore::Schema::Checker::Reconciler::Constructor
     # @since 0.1.0
     def append_definitions(reconciler, &definitions)
       reconciler.instance_eval(&definitions)
+    end
+
+    # @param reconciler [SmartCore::Schema::Checker::Reconciler]
+    # @param strict_mode [NilClass, String, Symbol]
+    # @return [void]
+    #
+    # @api private
+    # @since 0.2.0
+    def set_strict_mode(reconciler, strict_mode)
+      return if strict_mode == nil
+
+      mode = STRICT_MODES.fetch(strict_mode) do
+        raise(SmartCore::Schema::ArgumentError, <<~ERROR_MESSAGE)
+          Unsupported schmea strict mode "#{strict_mode}".
+          SmartCore::Schema supports "strict" and "non_strict" modes only.
+        ERROR_MESSAGE
+      end
+
+      reconciler.strict!(mode)
     end
 
     # @param definitions [Proc, NilClass]

--- a/lib/smart_core/schema/checker/reconciler/constructor.rb
+++ b/lib/smart_core/schema/checker/reconciler/constructor.rb
@@ -2,18 +2,18 @@
 
 # @api private
 # @since 0.1.0
-# @version 0.2.0
+# @version 0.3.0
 module SmartCore::Schema::Checker::Reconciler::Constructor
   # @return [Hash<String,Boolean>]
   #
   # @api private
-  # @since 0.2.0
+  # @since 0.3.0
   STRICT_MODES = { strict: true, 'strict' => true, non_strict: false, 'non_strict' => true }.freeze
 
   # @return [Boolean]
   #
   # @pai private
-  # @since 0.2.0
+  # @since 0.3.0
   DEFAULT_STRICT_BEHAVIOR = STRICT_MODES[:strict] # NOTE: means `strict by default`
 
   class << self
@@ -32,18 +32,18 @@ module SmartCore::Schema::Checker::Reconciler::Constructor
     # @return [void]
     #
     # @api private
-    # @since 0.2.0
+    # @since 0.3.0
     def set_strict_mode(reconciler, strict_mode)
       return if strict_mode == nil
 
-      mode = STRICT_MODES.fetch(strict_mode) do
+      is_strict = STRICT_MODES.fetch(strict_mode) do
         raise(SmartCore::Schema::ArgumentError, <<~ERROR_MESSAGE)
-          Unsupported schmea strict mode "#{strict_mode}".
+          Unsupported strict mode "#{strict_mode}".
           SmartCore::Schema supports "strict" and "non_strict" modes only.
         ERROR_MESSAGE
       end
 
-      reconciler.strict!(mode)
+      reconciler.strict!(is_strict)
     end
 
     # @param definitions [Proc, NilClass]

--- a/lib/smart_core/schema/checker/reconciler/matcher.rb
+++ b/lib/smart_core/schema/checker/reconciler/matcher.rb
@@ -2,7 +2,9 @@
 
 # @api private
 # @since 0.1.0
+# @version 0.3.0
 module SmartCore::Schema::Checker::Reconciler::Matcher
+  require_relative 'matcher/options'
   require_relative 'matcher/result'
   require_relative 'matcher/result_finalizer'
 
@@ -13,39 +15,46 @@ module SmartCore::Schema::Checker::Reconciler::Matcher
     #
     # @api private
     # @since 0.1.0
+    # @version 0.3.0
     def match(reconciler, verifiable_hash)
+      matcher_options = Options.build_from(reconciler)
+
       Result.new(verifiable_hash).tap do |result|
-        match_for_contract_keys(reconciler, verifiable_hash, result)
-        match_for_extra_keys(reconciler, verifiable_hash, result)
+        match_for_contract_keys(reconciler, matcher_options, verifiable_hash, result)
+        match_for_extra_keys(reconciler, matcher_options, verifiable_hash, result)
       end
     end
 
     private
 
     # @param reconciler [SmartCore::Schema::Checker::Reconciler]
+    # @param matcher_options [SmartCore::Schema::Checker::Reconciler::Matcher::Options]
     # @param verifiable_hash [SmartCore::Schema::Checker::VerifiableHash]
     # @param result [SmartCore::Schema::Checker::Reconciler::Matcher::Result]
     # @return [void]
     #
     # @api private
     # @since 0.1.0
-    def match_for_contract_keys(reconciler, verifiable_hash, result)
+    # @version 0.3.0
+    def match_for_contract_keys(reconciler, matcher_options, verifiable_hash, result)
       reconciler.__contract_rules.each_rule do |rule|
-        verification_result = rule.__verify!(verifiable_hash)
+        verification_result = rule.__verify!(verifiable_hash, matcher_options)
         result.contract_key_result(verification_result)
       end
     end
 
     # @param reconciler [SmartCore::Schema::Checker::Reconciler]
+    # @param matcher_options [SmartCore::Schema::Checker::Reconciler::Matcher::Options]
     # @param verifiable_hash [SmartCore::Schema::Checker::VerifiableHash]
     # @param result [SmartCore::Schema::Checker::Reconciler::Matcher::Result]
     # @return [void]
     #
     # @api private
     # @since 0.1.0
-    def match_for_extra_keys(reconciler, verifiable_hash, result)
+    # @version 0.3.0
+    def match_for_extra_keys(reconciler, matcher_options, verifiable_hash, result)
       verification_result = reconciler.__extra_keys_contract.__verify!(
-        verifiable_hash, reconciler.__contract_rules
+        verifiable_hash, reconciler.__contract_rules, matcher_options
       )
       result.extra_keys_result(verification_result)
     end

--- a/lib/smart_core/schema/checker/reconciler/matcher/options.rb
+++ b/lib/smart_core/schema/checker/reconciler/matcher/options.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# @api private
+# @since 0.3.0
+class SmartCore::Schema::Checker::Reconciler::Matcher::Options
+  class << self
+    # @param reconciler [SmartCore::Schema::Checker::Reconciler]
+    # @return [SmartCore::Schema::Checker::Reconciler::Matcher::Options]
+    #
+    # @api private
+    # @since 0.3.0
+    def build_from(reconciler)
+      new(reconciler.__strict?)
+    end
+  end
+
+  # @param is_strict_schema [Boolean]
+  # @return [void]
+  #
+  # @api private
+  # @since 0.3.0
+  def initialize(is_strict_schema)
+    @is_strict_schema = is_strict_schema
+  end
+
+  # @return [Boolean]
+  #
+  # @api private
+  # @since 0.3.0
+  def strict_schema?
+    @is_strict_schema
+  end
+end

--- a/lib/smart_core/schema/checker/reconciler/matcher/result_finalizer.rb
+++ b/lib/smart_core/schema/checker/reconciler/matcher/result_finalizer.rb
@@ -132,11 +132,12 @@ module SmartCore::Schema::Checker::Reconciler::Matcher::ResultFinalizer
     # @param errors [Hash]
     # @param extra_keys [Set]
     # @param spread_keys [Set]
+    # @param initial_error_key [NilClass, String]
     # @return [Array<Hash<String,Set<Symbol>>,Set<String>]
     #
     # @api private
     # @since 0.1.0
-    # @version 0.2.0
+    # @version 0.3.0
     # rubocop:disable Metrics/AbcSize
     def compile_errors(errors, extra_keys, spread_keys, initial_error_key = nil)
       compiled_errors = ERRORS_CONTAINER_BUILDER.call

--- a/lib/smart_core/schema/checker/reconciler/matcher/result_finalizer.rb
+++ b/lib/smart_core/schema/checker/reconciler/matcher/result_finalizer.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
+# TODO: refactor error data propagating (with Value Object)
+
 # @api private
 # @since 0.1.0
+# @version 0.3.0
 module SmartCore::Schema::Checker::Reconciler::Matcher::ResultFinalizer
   # @return [Proc]
   #
@@ -15,6 +18,12 @@ module SmartCore::Schema::Checker::Reconciler::Matcher::ResultFinalizer
   # @since 0.1.0
   EXTRA_KEYS_CONTAINER_BUILDER = -> { Set.new }
 
+  # @return [Proc]
+  #
+  # @api private
+  # @since 0.3.0
+  SPREAD_KEYS_CONTAINER_BUILDER = -> { Set.new }
+
   # @return [Symbol]
   #
   # @api private
@@ -27,26 +36,32 @@ module SmartCore::Schema::Checker::Reconciler::Matcher::ResultFinalizer
     #
     # @ai privates
     # @since 0.1.0
+    # @version 0.3.0
+    # rubocop:disable Layout/LineLength
     def finalize(result)
-      schema_errors, extra_keys = aggregate_errors(result)
-      schema_errors, extra_keys = compile_errors(schema_errors, extra_keys)
-      build_final_result(result, schema_errors, extra_keys)
+      schema_errors, extra_keys, spread_keys = aggregate_errors(result)
+      schema_errors, extra_keys, spread_keys = compile_errors(schema_errors, extra_keys, spread_keys)
+      build_final_result(result, schema_errors, extra_keys, spread_keys)
     end
+    # rubocop:enable Layout/LineLength
 
     private
 
     # @param result [SmartCore::Schema::Checker::Reconciler::Matcher::Result]
     # @param schema_errors [Hash<String,Array<Symbol>>]
     # @param extra_keys [Set<String>]
+    # @param spread_keys [Set<String>]
     # @return [SmartCore::Schema::Result]
     #
     # @api private
     # @since 0.1.0
-    def build_final_result(result, schema_errors, extra_keys)
+    # @version 0.3.0
+    def build_final_result(result, schema_errors, extra_keys, spread_keys)
       SmartCore::Schema::Result.new(
         result.verifiable_hash.source,
         schema_errors.freeze,
-        extra_keys.freeze
+        extra_keys.freeze,
+        spread_keys.freeze
       )
     end
 
@@ -58,6 +73,7 @@ module SmartCore::Schema::Checker::Reconciler::Matcher::ResultFinalizer
     def aggregate_errors(result)
       schema_errors = ERRORS_CONTAINER_BUILDER.call
       extra_keys = EXTRA_KEYS_CONTAINER_BUILDER.call
+      spread_keys = SPREAD_KEYS_CONTAINER_BUILDER.call
 
       result.each_result do |concrete_result|
         case concrete_result
@@ -65,15 +81,16 @@ module SmartCore::Schema::Checker::Reconciler::Matcher::ResultFinalizer
           aggregate_verifier_errors(concrete_result, schema_errors)
         when SmartCore::Schema::Checker::Rules::ExtraKeys::Failure
           aggregate_extra_keys_errors(concrete_result, extra_keys)
+        when SmartCore::Schema::Checker::Rules::ExtraKeys::Success
+          aggregate_spread_keys_notice(concrete_result, spread_keys)
         end
       end
 
-      [schema_errors, extra_keys]
+      [schema_errors, extra_keys, spread_keys]
     end
 
     # @param result [SmartCore::Schema::Checker::Rules::Verifier::Result]
     # @param errors [Hash<String,Array<String>|Hash<String,Hash>>]
-    # @param extra_keys [Set<String>]
     # @return [void]
     #
     # @api private
@@ -102,19 +119,36 @@ module SmartCore::Schema::Checker::Reconciler::Matcher::ResultFinalizer
       extra_keys.merge(result.extra_keys)
     end
 
+    # @param result [SmartCore::Schema::Checker::Rules::ExtraKeys::Success]
+    # @param spread_keys [Set<String>]
+    # @return [void]
+    #
+    # @api private
+    # @since 0.3.0
+    def aggregate_spread_keys_notice(result, spread_keys)
+      spread_keys.merge(result.spread_keys)
+    end
+
     # @param errors [Hash]
     # @param extra_keys [Set]
+    # @param spread_keys [Set]
     # @return [Array<Hash<String,Set<Symbol>>,Set<String>]
     #
     # @api private
     # @since 0.1.0
     # @version 0.2.0
     # rubocop:disable Metrics/AbcSize
-    def compile_errors(errors, extra_keys, initial_error_key = nil)
+    def compile_errors(errors, extra_keys, spread_keys, initial_error_key = nil)
       compiled_errors = ERRORS_CONTAINER_BUILDER.call
       compiled_extra_keys = EXTRA_KEYS_CONTAINER_BUILDER.call
+      compiled_spread_keys = SPREAD_KEYS_CONTAINER_BUILDER.call
 
       compiled_extra_keys.merge(extra_keys).map! do |key|
+        # dot-notated nested keys
+        initial_error_key ? "#{initial_error_key}.#{key}" : key
+      end
+
+      compiled_spread_keys.merge(spread_keys).map! do |key|
         # dot-notated nested keys
         initial_error_key ? "#{initial_error_key}.#{key}" : key
       end
@@ -129,11 +163,13 @@ module SmartCore::Schema::Checker::Reconciler::Matcher::ResultFinalizer
             compiled_errors[compiled_key] << error
           when Array # nested errors
             sub_errors, sub_extra_keys = error
-            compiled_sub_errors, compiled_sub_extra_keys = compile_errors(
-              sub_errors, sub_extra_keys, compiled_key
+            sub_spread_keys = SPREAD_KEYS_CONTAINER_BUILDER.call
+            compiled_sub_errors, compiled_sub_extra_keys, compiled_sub_spread_keys = compile_errors(
+              sub_errors, sub_extra_keys, sub_spread_keys, compiled_key
             )
             compiled_errors.merge!(compiled_sub_errors)
             compiled_extra_keys.merge(compiled_sub_extra_keys)
+            compiled_spread_keys.merge(compiled_sub_spread_keys)
           end
         end
       end
@@ -142,7 +178,7 @@ module SmartCore::Schema::Checker::Reconciler::Matcher::ResultFinalizer
         compiled_errors[compiled_extra_key] << EXTRA_KEY_ERROR_CODE
       end
 
-      [compiled_errors, compiled_extra_keys]
+      [compiled_errors, compiled_extra_keys, compiled_spread_keys]
     end
     # rubocop:enable Metrics/AbcSize
   end

--- a/lib/smart_core/schema/checker/reconciler/matcher/result_finalizer.rb
+++ b/lib/smart_core/schema/checker/reconciler/matcher/result_finalizer.rb
@@ -138,7 +138,7 @@ module SmartCore::Schema::Checker::Reconciler::Matcher::ResultFinalizer
     # @api private
     # @since 0.1.0
     # @version 0.3.0
-    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
     def compile_errors(errors, extra_keys, spread_keys, initial_error_key = nil)
       compiled_errors = ERRORS_CONTAINER_BUILDER.call
       compiled_extra_keys = EXTRA_KEYS_CONTAINER_BUILDER.call
@@ -181,6 +181,6 @@ module SmartCore::Schema::Checker::Reconciler::Matcher::ResultFinalizer
 
       [compiled_errors, compiled_extra_keys, compiled_spread_keys]
     end
-    # rubocop:enable Metrics/AbcSize
+    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
   end
 end

--- a/lib/smart_core/schema/checker/reconciler/matcher/result_finalizer.rb
+++ b/lib/smart_core/schema/checker/reconciler/matcher/result_finalizer.rb
@@ -61,7 +61,7 @@ module SmartCore::Schema::Checker::Reconciler::Matcher::ResultFinalizer
         result.verifiable_hash.source,
         schema_errors.freeze,
         extra_keys.freeze,
-        spread_keys.freeze
+        SPREAD_KEYS_CONTAINER_BUILDER.call.freeze # TODO: spread_keys.freeze
       )
     end
 

--- a/lib/smart_core/schema/checker/rules/base.rb
+++ b/lib/smart_core/schema/checker/rules/base.rb
@@ -49,8 +49,8 @@ class SmartCore::Schema::Checker::Rules::Base
   #   @return [SmartCore::Schema::Checker::Rules::Requirement::Optional]
   #   @return [SmartCore::Schema::Checker::Rules::Requirement::Required]
 
-  # @param matcher_options [SmartCore::Schema::Checker::Reconciler::Matcher::Options]
   # @param verifiable_hash [Hash<String|Symbol,Any>]
+  # @param matcher_options [SmartCore::Schema::Checker::Reconciler::Matcher::Options]
   # @return [SmartCore::Schema::Checker::Rules::Verifier::Result]
   #
   # @api private

--- a/lib/smart_core/schema/checker/rules/base.rb
+++ b/lib/smart_core/schema/checker/rules/base.rb
@@ -35,17 +35,19 @@ class SmartCore::Schema::Checker::Rules::Base
     define_nested_reconciler(&nested_definitions)
   end
 
-  # @!method requirement
-  #   @return [SmartCore::Schema::Checker::Rules::Requirement::Optional]
+  # @!method requirement @return [SmartCore::Schema::Checker::Rules::Requirement::Optional]
   #   @return [SmartCore::Schema::Checker::Rules::Requirement::Required]
 
+  # @param matcher_options [SmartCore::Schema::Checker::Reconciler::Matcher::Options]
   # @param verifiable_hash [Hash<String|Symbol,Any>]
   # @return [SmartCore::Schema::Checker::Rules::Verifier::Result]
   #
   # @api private
   # @since 0.1.0
-  def __verify!(verifiable_hash)
-    SmartCore::Schema::Checker::Rules::Verifier.verify!(self, verifiable_hash)
+  def __verify!(verifiable_hash, matcher_options)
+    SmartCore::Schema::Checker::Rules::Verifier.verify!(
+      self, matcher_options, verifiable_hash
+    )
   end
 
   # @param required_type [String, Symbol, SmartCore::Types::Primitive]

--- a/lib/smart_core/schema/checker/rules/extra_keys.rb
+++ b/lib/smart_core/schema/checker/rules/extra_keys.rb
@@ -21,10 +21,7 @@ module SmartCore::Schema::Checker::Rules::ExtraKeys
     def __verify!(verifiable_hash, rules, matcher_options)
       extra_keys = verifiable_hash.keys - rules.keys
 
-      case
-      when extra_keys.empty?
-        Success.new(extra_keys, matcher_options)
-      when extra_keys.any? && !matcher_options.strict_schema?
+      if extra_keys.empty? || (extra_keys.any? && !matcher_options.strict_schema?)
         Success.new(extra_keys, matcher_options)
       else
         Failure.new(extra_keys, matcher_options)

--- a/lib/smart_core/schema/checker/rules/extra_keys.rb
+++ b/lib/smart_core/schema/checker/rules/extra_keys.rb
@@ -2,21 +2,33 @@
 
 # @api private
 # @since 0.1.0
+# @version 0.3.0
 module SmartCore::Schema::Checker::Rules::ExtraKeys
+  require_relative 'extra_keys/result'
   require_relative 'extra_keys/success'
   require_relative 'extra_keys/failure'
 
   class << self
     # @param verifiable_hash [SmartCore::Schema::Checker::VerifiableHash]
     # @param rules [SmartCore::Schema::Checker::Rules]
+    # @param matcher_options [SmartCore::Schema::Checker::Reconciler::Matcher::Options]
     # @return [SmartCore::Schema::Checker::Rules::ExtraKeys::Success]
     # @return [SmartCore::Schema::Checker::Rules::ExtraKeys::Failure]
     #
     # @api private
     # @since 0.1.0
-    def __verify!(verifiable_hash, rules)
+    # @version 0.3.0
+    def __verify!(verifiable_hash, rules, matcher_options)
       extra_keys = verifiable_hash.keys - rules.keys
-      extra_keys.empty? ? Success.new : Failure.new(extra_keys)
+
+      case
+      when extra_keys.empty?
+        Success.new(extra_keys, matcher_options)
+      when extra_keys.any? && !matcher_options.strict_schema?
+        Success.new(extra_keys, matcher_options)
+      else
+        Failure.new(extra_keys, matcher_options)
+      end
     end
   end
 end

--- a/lib/smart_core/schema/checker/rules/extra_keys/failure.rb
+++ b/lib/smart_core/schema/checker/rules/extra_keys/failure.rb
@@ -1,36 +1,24 @@
 # frozen_string_literal: true
 
-# @api private
-# @since 0.1.0
-class SmartCore::Schema::Checker::Rules::ExtraKeys::Failure
-  # @return extra_keys [Array<String>]
-  #
+module SmartCore::Schema::Checker::Rules::ExtraKeys
   # @api private
   # @since 0.1.0
-  attr_reader :extra_keys
+  # @version 0.3.0
+  class Failure < Result
+    # @return [Boolean]
+    #
+    # @api private
+    # @since 0.1.0
+    def success?
+      false
+    end
 
-  # @param extra_keys [Array<String>]
-  # @return [void]
-  #
-  # @api private
-  # @since 0.1.0
-  def initialize(extra_keys)
-    @extra_keys = extra_keys
-  end
-
-  # @return [Boolean]
-  #
-  # @api private
-  # @since 0.1.0
-  def success?
-    false
-  end
-
-  # @return [Boolean]
-  #
-  # @api private
-  # @since 0.1.0
-  def failure?
-    true
+    # @return [Boolean]
+    #
+    # @api private
+    # @since 0.1.0
+    def failure?
+      true
+    end
   end
 end

--- a/lib/smart_core/schema/checker/rules/extra_keys/result.rb
+++ b/lib/smart_core/schema/checker/rules/extra_keys/result.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# @apbstract
+#
+# @api private
+# @since 0.3.0
+class SmartCore::Schema::Checker::Rules::ExtraKeys::Result
+  # @return [Array<String>]
+  #
+  # @api private
+  # @since 0.3.0
+  attr_reader :extra_keys
+
+  # @return [SmartCore::Schema::Checker::Reconciler::Matcher::Options]
+  #
+  # @api private
+  # @since 0.3.0
+  attr_reader :matcher_options
+
+  # @param extra_keys [Array<String>]
+  # @param matcher_options [SmartCore::Schema::Checker::Reconciler::Matcher::Options]
+  # @return [void]
+  #
+  # @api private
+  # @since 0.1.0
+  # @version 0.3.0
+  def initialize(extra_keys, matcher_options)
+    @extra_keys = extra_keys
+    @matcher_options = matcher_options
+  end
+
+  # @!method success?
+  #   @return [Boolean]
+
+  # @!method failure?
+  #   @return [Boolean]
+end

--- a/lib/smart_core/schema/checker/rules/extra_keys/success.rb
+++ b/lib/smart_core/schema/checker/rules/extra_keys/success.rb
@@ -5,6 +5,12 @@ module SmartCore::Schema::Checker::Rules::ExtraKeys
   # @since 0.1.0
   # @version 0.3.0
   class Success < Result
+    # @return [Array<String>]
+    #
+    # @api private
+    # @since 0.3.0
+    alias_method :spread_keys, :extra_keys
+
     # @return [Boolean]
     #
     # @api private

--- a/lib/smart_core/schema/checker/rules/extra_keys/success.rb
+++ b/lib/smart_core/schema/checker/rules/extra_keys/success.rb
@@ -1,21 +1,24 @@
 # frozen_string_literal: true
 
-# @api private
-# @since 0.1.0
-class SmartCore::Schema::Checker::Rules::ExtraKeys::Success
-  # @return [Boolean]
-  #
+module SmartCore::Schema::Checker::Rules::ExtraKeys
   # @api private
   # @since 0.1.0
-  def success?
-    true
-  end
+  # @version 0.3.0
+  class Success < Result
+    # @return [Boolean]
+    #
+    # @api private
+    # @since 0.1.0
+    def success?
+      true
+    end
 
-  # @return [Boolean]
-  #
-  # @api private
-  # @since 0.1.0
-  def failure?
-    false
+    # @return [Boolean]
+    #
+    # @api private
+    # @since 0.1.0
+    def failure?
+      false
+    end
   end
 end

--- a/lib/smart_core/schema/checker/rules/optional.rb
+++ b/lib/smart_core/schema/checker/rules/optional.rb
@@ -2,6 +2,7 @@
 
 # @api private
 # @since 0.1.0
+# @version 0.3.0
 class SmartCore::Schema::Checker::Rules::Optional < SmartCore::Schema::Checker::Rules::Base
   # @return [SmartCore::Schema::Checker::Rules::Requirement::Optional]
   #
@@ -9,14 +10,16 @@ class SmartCore::Schema::Checker::Rules::Optional < SmartCore::Schema::Checker::
   # @since 0.1.0
   attr_reader :requirement
 
+  # @param root_reconciler [SmartCore::Schema::Checker::Reconciler]
   # @param schema_key [String, Symbol]
   # @param nested_definitions [Block]
   # @return [void]
   #
   # @api private
   # @since 0.1.0
-  def initialize(schema_key, &nested_definitions)
-    super(schema_key, &nested_definitions)
+  # @version 0.3.0
+  def initialize(root_reconciler, schema_key, &nested_definitions)
+    super(root_reconciler, schema_key, &nested_definitions)
     @requirement = SmartCore::Schema::Checker::Rules::Requirement::Optional.new(self)
   end
 end

--- a/lib/smart_core/schema/checker/rules/options/filled.rb
+++ b/lib/smart_core/schema/checker/rules/options/filled.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-# @api private
-# @since 0.1.0
 class SmartCore::Schema::Checker::Rules::Options
+  # @api private
+  # @since 0.1.0
   class Filled < Empty
-    # @note Constant is used only for clarity (for other developers).
+    # @note Constant is used only for other developers.
     # @return [Symbol]
     #
     # @api private

--- a/lib/smart_core/schema/checker/rules/options/type.rb
+++ b/lib/smart_core/schema/checker/rules/options/type.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-# @api private
-# @since 0.1.0
 class SmartCore::Schema::Checker::Rules::Options
+  # @api private
+  # @since 0.1.0
   class Type < Empty
     # @note Constant is used only for clarity (for other developers)
     # @return [Symbol]

--- a/lib/smart_core/schema/checker/rules/required.rb
+++ b/lib/smart_core/schema/checker/rules/required.rb
@@ -2,6 +2,7 @@
 
 # @api private
 # @since 0.1.0
+# @version 0.3.0
 class SmartCore::Schema::Checker::Rules::Required < SmartCore::Schema::Checker::Rules::Base
   # @return [SmartCore::Schema::Checker::Rules::Requirement::Required]
   #
@@ -9,14 +10,16 @@ class SmartCore::Schema::Checker::Rules::Required < SmartCore::Schema::Checker::
   # @since 0.1.0
   attr_reader :requirement
 
+  # @param root_reconciler [SmartCore::Schema::Checker::Reconciler]
   # @param schema_key [String, Symbol]
   # @param nested_definitions [Block]
   # @return [void]
   #
   # @api private
   # @since 0.1.0
-  def initialize(schema_key, &nested_definitions)
-    super(schema_key, &nested_definitions)
+  # @version 0.3.0
+  def initialize(root_reconciler, schema_key, &nested_definitions)
+    super(root_reconciler, schema_key, &nested_definitions)
     @requirement = SmartCore::Schema::Checker::Rules::Requirement::Required.new(self)
   end
 end

--- a/lib/smart_core/schema/checker/rules/verifier.rb
+++ b/lib/smart_core/schema/checker/rules/verifier.rb
@@ -7,12 +7,13 @@ module SmartCore::Schema::Checker::Rules::Verifier
 
   class << self
     # @param rule [SmartCore::Schema::Checker::Rules::Base]
+    # @param matcher_options [SmartCore::Schema::Checker::Reconciler::Matcher::Options]
     # @param verifiable_hash [SmartCore::Schema::Checker::VerifiableHash]
     # @return [SmartCore::Schema::Checker::Rules::Verifier::Result]
     #
     # @api private
     # @since 0.1.0
-    def verify!(rule, verifiable_hash)
+    def verify!(rule, matcher_options, verifiable_hash)
       SmartCore::Schema::Checker::Rules::Verifier::Result.new(rule).tap do |result|
         requirement = result << check_requirement(rule, verifiable_hash)
         next result if requirement.required? && requirement.failure?

--- a/lib/smart_core/schema/checker/rules/verifier.rb
+++ b/lib/smart_core/schema/checker/rules/verifier.rb
@@ -2,6 +2,7 @@
 
 # @api private
 # @since 0.1.0
+# @version 0.3.0
 module SmartCore::Schema::Checker::Rules::Verifier
   require_relative 'verifier/result'
 
@@ -13,6 +14,7 @@ module SmartCore::Schema::Checker::Rules::Verifier
     #
     # @api private
     # @since 0.1.0
+    # @version 0.3.0
     def verify!(rule, matcher_options, verifiable_hash)
       SmartCore::Schema::Checker::Rules::Verifier::Result.new(rule).tap do |result|
         requirement = result << check_requirement(rule, verifiable_hash)

--- a/lib/smart_core/schema/dsl.rb
+++ b/lib/smart_core/schema/dsl.rb
@@ -36,7 +36,7 @@ module SmartCore::Schema::DSL
 
   # @api private
   # @since 0.1.0
-  # @version 0.2.0
+  # @version 0.3.0
   module ClassMethods
     # @return [SmartCore::Schema::Checker]
     #
@@ -46,14 +46,15 @@ module SmartCore::Schema::DSL
       @__schema_checker__
     end
 
-    # @note nil strict mode means `do not change current mode`
     # @param strict_mode [NilClass, String, Symbol]
     # @param definitions [Block]
     # @return [void]
     #
+    # @note nil strict mode means `do not change current mode`
+    #
     # @api public
     # @since 0.1.0
-    # @version 0.2.0
+    # @version 0.3.0
     def schema(strict_mode = nil, &definitions)
       __schema_checker__.invoke_in_pipe do
         set_strict_mode(strict_mode)
@@ -64,7 +65,7 @@ module SmartCore::Schema::DSL
     # @return [void]
     #
     # @api public
-    # @since 0.2.0
+    # @since 0.3.0
     def strict!
       __schema_checker__.set_strict_mode(:strict)
     end
@@ -72,7 +73,7 @@ module SmartCore::Schema::DSL
     # @return [void]
     #
     # @api public
-    # @since 0.2.0
+    # @since 0.3.0
     def non_strict!
       __schema_checker__.set_strict_mode(:non_strict)
     end

--- a/lib/smart_core/schema/dsl.rb
+++ b/lib/smart_core/schema/dsl.rb
@@ -36,6 +36,7 @@ module SmartCore::Schema::DSL
 
   # @api private
   # @since 0.1.0
+  # @version 0.2.0
   module ClassMethods
     # @return [SmartCore::Schema::Checker]
     #
@@ -45,13 +46,35 @@ module SmartCore::Schema::DSL
       @__schema_checker__
     end
 
+    # @note nil strict mode means `do not change current mode`
+    # @param strict_mode [NilClass, String, Symbol]
     # @param definitions [Block]
     # @return [void]
     #
     # @api public
     # @since 0.1.0
-    def schema(&definitions)
-      __schema_checker__.append_schema_definitions(&definitions)
+    # @version 0.2.0
+    def schema(strict_mode = nil, &definitions)
+      __schema_checker__.invoke_in_pipe do
+        set_strict_mode(strict_mode)
+        append_schema_definitions(&definitions)
+      end
+    end
+
+    # @return [void]
+    #
+    # @api public
+    # @since 0.2.0
+    def strict!
+      __schema_checker__.set_strict_mode(:strict)
+    end
+
+    # @return [void]
+    #
+    # @api public
+    # @since 0.2.0
+    def non_strict!
+      __schema_checker__.set_strict_mode(:non_strict)
     end
   end
 end

--- a/lib/smart_core/schema/result.rb
+++ b/lib/smart_core/schema/result.rb
@@ -2,6 +2,7 @@
 
 # @api private
 # @since 0.1.0
+# @version 0.3.0
 class SmartCore::Schema::Result
   # @return [Hash<String,Any>]
   #
@@ -21,15 +22,26 @@ class SmartCore::Schema::Result
   # @since 0.1.0
   attr_reader :extra_keys
 
+  # @return [Set<String>]
+  #
+  # @api public
+  # @since 0.3.0
+  attr_reader :spread_keys
+
   # @param source [Hash<String|Symbol,Any>]
+  # @param errors [Hash<String,Array<Symbol>]
+  # @param extra_keys [Set<String>]
+  # @param spread_keys [Set<String>]
   # @return [void]
   #
   # @api private
   # @since 0.1.0
-  def initialize(source, errors, extra_keys)
+  # @version 0.3.0
+  def initialize(source, errors, extra_keys, spread_keys)
     @source = source
     @errors = errors
     @extra_keys = extra_keys
+    @spread_keys = spread_keys
   end
 
   # @return [Boolean]

--- a/spec/smart_schema_spec.rb
+++ b/spec/smart_schema_spec.rb
@@ -7,13 +7,17 @@ RSpec.describe SmartCore::Schema do
 
   specify 'smoke' do
     class MySchema < SmartCore::Schema
-      schema do
+      schema(:non_strict) do
+        strict!
+
         required(:key) do
           optional(:data).type(:string)
           optional(:value).type(:numeric)
           required(:name).type(:string)
           required(:age).type(:integer)
           required(:rizdos) do
+            non_strict!
+
             required(:pui).type(SmartCore::Types::Value::String)
             required(:cheburek) do
               required(:jaja).filled

--- a/spec/smart_schema_spec.rb
+++ b/spec/smart_schema_spec.rb
@@ -101,6 +101,7 @@ RSpec.describe SmartCore::Schema do
     # expect(result_2.spread_keys).to contain_exactly(
     #   'key.rizdos.che'
     # )
+    expect(result_2.spread_keys).to be_empty
 
     # valid state
     result_3 = MySchema.new.validate({
@@ -118,6 +119,7 @@ RSpec.describe SmartCore::Schema do
     expect(result_3.success?).to eq(true)
     expect(result_3.errors).to eq({})
     expect(result_3.extra_keys).to be_empty
+    expect(result_3.spread_keys).to be_empty
 
     expect(MySchema.new.valid?({})).to eq(false)
     expect(MySchema.new.valid?({
@@ -139,10 +141,10 @@ RSpec.describe SmartCore::Schema do
     end
 
     result_4 = StrictByDefaultSchema.new.validate({ jaga: 'test', gaga: 123 })
-
     expect(result_4.success?).to eq(false)
     expect(result_4.failure?).to eq(true)
     expect(result_4.extra_keys).to contain_exactly('gaga')
+    expect(result_4.spread_keys).to be_empty
 
     class InheritableModeSchema < SmartCore::Schema
       schema(:non_strict) do # non-strict
@@ -171,10 +173,23 @@ RSpec.describe SmartCore::Schema do
       },
       fek: 5
     })
-
     expect(result_5.success?).to eq(false)
     expect(result_5.failure?).to eq(true)
     expect(result_5.extra_keys).to contain_exactly('kek.jek.aza')
+
+    class InitialNonStrictSchema < SmartCore::Schema
+      non_strict!
+
+      schema do
+        required(:pek)
+      end
+    end
+
+    result_6 = InitialNonStrictSchema.new.validate({ pek: 1, kek: 2 })
+    expect(result_6.success?).to eq(true)
+    expect(result_6.failure?).to eq(false)
+    expect(result_6.extra_keys).to be_empty
+    expect(result_6.spread_keys).to be_empty
 
     expect do # incompatible dsl (schema)
       Class.new(SmartCore::Schema) { schema { non_required } }

--- a/spec/smart_schema_spec.rb
+++ b/spec/smart_schema_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe SmartCore::Schema do
       'c_key' => [:required_key_not_found]
     )
     expect(result_1.extra_keys).to be_empty
+    expect(result_1.spread_keys).to be_empty
 
     # invalid schema
     result_2 = MySchema.new.validate({
@@ -67,9 +68,16 @@ RSpec.describe SmartCore::Schema do
         data: 123,
         value: 123,
         name: 'D@iVeR',
-        rizdos: { pui: 123, che: true, cheburek: { jaja: nil }, urban_strike: {} },
-        cheburek: {},
-        urban_strike: {}
+        rizdos: {
+          pui: 123, 
+          che: true, # spread-key (key from non-strict schema)
+          cheburek: { 
+            jaja: nil 
+          },
+          urban_strike: {} 
+        },
+        cheburek: {}, # extra-key (key from strict schema)
+        urban_strike: {} # extra-key (key from strict schema)
       },
       c_key: { itmo: {} }
     })
@@ -84,13 +92,15 @@ RSpec.describe SmartCore::Schema do
       'c_key.itmo.gigabyte' => [:required_key_not_found],
       'key.cheburek' => [:extra_key],
       'key.urban_strike' => [:extra_key],
-      'key.rizdos.che' => [:extra_key]
     )
     expect(result_2.extra_keys).to contain_exactly(
       'key.cheburek',
-      'key.urban_strike',
-      'key.rizdos.che'
+      'key.urban_strike'
     )
+    # TODO: spread keys aggregation and check
+    # expect(result_2.spread_keys).to contain_exactly(
+    #   'key.rizdos.che'
+    # )
 
     # valid state
     result_3 = MySchema.new.validate({

--- a/spec/smart_schema_spec.rb
+++ b/spec/smart_schema_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe SmartCore::Schema do
 
   specify 'smoke' do
     class MySchema < SmartCore::Schema
+      strict!
+
       schema(:non_strict) do
         strict!
 

--- a/spec/smart_schema_spec.rb
+++ b/spec/smart_schema_spec.rb
@@ -69,12 +69,12 @@ RSpec.describe SmartCore::Schema do
         value: 123,
         name: 'D@iVeR',
         rizdos: {
-          pui: 123, 
+          pui: 123,
           che: true, # spread-key (key from non-strict schema)
-          cheburek: { 
-            jaja: nil 
+          cheburek: {
+            jaja: nil
           },
-          urban_strike: {} 
+          urban_strike: {}
         },
         cheburek: {}, # extra-key (key from strict schema)
         urban_strike: {} # extra-key (key from strict schema)
@@ -91,7 +91,7 @@ RSpec.describe SmartCore::Schema do
       'b_key' => [:required_key_not_found],
       'c_key.itmo.gigabyte' => [:required_key_not_found],
       'key.cheburek' => [:extra_key],
-      'key.urban_strike' => [:extra_key],
+      'key.urban_strike' => [:extra_key]
     )
     expect(result_2.extra_keys).to contain_exactly(
       'key.cheburek',


### PR DESCRIPTION
DSL (in schemas):

```ruby
schema(:strict) # for strict schemas
schema(:non_strict) # for non-strict schemas

strict! # inside schema definition
non_strict! # inside schema definition
```

- `:strict` is used by default;
- you can make non-strict inner schemas in strict schemas;
- inner schemas inherits strict mode of their's outer schema;