### PR TITLE
[TypeSystem] type-object for nested validations (instead of alias)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+# [0.12.1] - 2026-02-18
+## Fixed
+- Nested schemas requires :hash type for their schema key, but
+  this type is resolved from the type alias, not from the type object.
+  - Added an object reference to the hash primitive in `type interop` subsystem (interop + abstract factory);
+  - each type system should provide hash type class:
+    - smart-core provides/recognizes nested structures with `SmartCore::Types::Hash`;
+    - dry-types provides/recognizes nested structures with `Dry::Types['hash']`;
+
+```ruby
+# before:
+
+require 'dry-types'
+SmartCore::Schema::Configuration.configure { |c| c.type_system = :dry_types }
+
+class MySchema < SmartCore::Schema
+  schema do
+    requried(:some_data) do # <- previously: failed on unrecognized type with :hash alias
+      requireqd(:some_key).type(Dry::Types['string'])
+    end
+  end
+end
+```
+
 # [0.12.0] - 2026-02-17
 ## Added
 - Plugin ecosystem;

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,7 +184,7 @@ PLATFORMS
 DEPENDENCIES
   armitage-rubocop (~> 1.81)
   bundler
-  dry-types
+  dry-types (~> 1.9)
   pry (~> 0.16)
   pry-doc (~> 1.7)
   rake (~> 13.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    smart_schema (0.12.0)
+    smart_schema (0.12.1)
       qonfig (~> 0.30)
       smart_engine (~> 0.17)
       smart_types (~> 0.8)
@@ -251,7 +251,7 @@ CHECKSUMS
   simplecov-html (0.13.2) sha256=bd0b8e54e7c2d7685927e8d6286466359b6f16b18cb0df47b508e8d73c777246
   simplecov_json_formatter (0.1.4) sha256=529418fbe8de1713ac2b2d612aa3daa56d316975d307244399fa4838c601b428
   smart_engine (0.17.0) sha256=33321745063737a9262f53ef7b5b040d65f8d8f5a5230ac6d3c2461b0404a52b
-  smart_schema (0.12.0)
+  smart_schema (0.12.1)
   smart_types (0.8.0) sha256=87879face377e4738e887f4b34657f8ed9572b8d22bd2deb6028bb45261a5bb7
   tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
   tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b

--- a/lib/smart_core/schema/checker/rules/base.rb
+++ b/lib/smart_core/schema/checker/rules/base.rb
@@ -95,7 +95,7 @@ class SmartCore::Schema::Checker::Rules::Base
   #
   # @api private
   # @since 0.1.0
-  # @version 0.3.0
+  # @version 0.12.1
   def define_nested_reconciler(&nested_definitions)
     return unless block_given?
 
@@ -105,6 +105,6 @@ class SmartCore::Schema::Checker::Rules::Base
       constructor.append_definitions(@nested_reconciler, &nested_definitions)
     end
 
-    type(:hash).filled
+    type(SmartCore::Schema.type_system.hash_type_object_for_nested_schemas).filled
   end
 end

--- a/lib/smart_core/schema/plugins/dry_types/dry_types/abstract_factory.rb
+++ b/lib/smart_core/schema/plugins/dry_types/dry_types/abstract_factory.rb
@@ -48,12 +48,20 @@ module SmartCore::Schema::TypeSystem
         ::Dry::Types::Any
       end
 
-      # @return [::Dry::Types::Type]
+      # @return [Class<::Dry::Types::Type>]
       #
       # @api private
       # @since 0.12.0
       def primitive_type_class
         ::Dry::Types::Type
+      end
+
+      # @return [::Dry::Types::Type]
+      #
+      # @api private
+      # @since 0.12.1
+      def hash_type_object_for_nested_schemas
+        ::Dry::Types['hash']
       end
 
       # @param type [::Dry::Types::Type]

--- a/lib/smart_core/schema/type_system/interop.rb
+++ b/lib/smart_core/schema/type_system/interop.rb
@@ -47,6 +47,14 @@ class SmartCore::Schema::TypeSystem::Interop
     def primitive_type_class
       self::AbstractFactory.primitive_type_class
     end
+
+    # @return [Any]
+    #
+    # @api private
+    # @since 0.12.1
+    def hash_type_object_for_nested_schemas
+      self::AbstractFactory.hash_type_object_for_nested_schemas
+    end
   end
 
   # @return [String]

--- a/lib/smart_core/schema/type_system/interop/abstract_factory.rb
+++ b/lib/smart_core/schema/type_system/interop/abstract_factory.rb
@@ -43,6 +43,18 @@ class SmartCore::Schema::TypeSystem::Interop::AbstractFactory
     # @since 0.12.0
     def prevent_incompatible_type!(type); end
 
+    # @return [Class]
+    #
+    # @api private
+    # @since 0.12.1
+    def primitive_type_class; end
+
+    # @return [Any]
+    #
+    # @api private
+    # @since 0.12.1
+    def hash_type_object_for_nested_schemas; end
+
     private
 
     # @param type [Any]

--- a/lib/smart_core/schema/type_system/smart_types/abstract_factory.rb
+++ b/lib/smart_core/schema/type_system/smart_types/abstract_factory.rb
@@ -56,6 +56,14 @@ module SmartCore::Schema::TypeSystem
         SmartCore::Types::Primitive
       end
 
+      # @return [SmartCore::Types::Value::Hash]
+      #
+      # @api private
+      # @since 0.12.1
+      def hash_type_object_for_nested_schemas
+        SmartCore::Types::Value::Hash
+      end
+
       # @param type [SmartCore::Types::Primitive]
       # @return [SmartCore::Schema::TypeSystem::SmartTypes::Operation::Validate]
       #

--- a/lib/smart_core/schema/version.rb
+++ b/lib/smart_core/schema/version.rb
@@ -7,8 +7,8 @@ module SmartCore
     #
     # @api public
     # @since 0.1.0
-    # @version 0.12.0
-    VERSION = '0.12.0'
+    # @version 0.12.1
+    VERSION = '0.12.1'
   end
   # rubocop:enable Style/StaticClass
 end

--- a/spec/smart_schema_spec.rb
+++ b/spec/smart_schema_spec.rb
@@ -54,14 +54,6 @@ RSpec.describe SmartCore::Schema do
       end
     end.to raise_error(SmartCore::Schema::ArgumentError)
 
-    # expect do
-      # class SomeFailableSchema < SmartCore::Schema
-      #   schema do
-      #     requried(:pek).type(:kek)
-      #   end
-      # end
-    # end
-
     result_1 = DryTypesTestingSchema.new.validate({ date: 123, memo: '123' })
     expect(result_1.success?).to eq(false)
     expect(result_1.errors).to match(

--- a/spec/smart_schema_spec.rb
+++ b/spec/smart_schema_spec.rb
@@ -20,6 +20,35 @@ RSpec.describe SmartCore::Schema do
     expect do
       Class.new(SmartCore::Schema) do
         schema do
+          # NOTE: should not fail on nested schemas
+          required(:pek) do
+            required(:kek).type(Dry::Types['integer'])
+          end
+        end
+      end
+    end.not_to raise_error
+
+    class PrimitiveNestedSchema < SmartCore::Schema
+      schema do
+        required(:nested) do
+          required(:field).type(:integer)
+        end
+      end
+    end
+
+    nested_schema = PrimitiveNestedSchema.new
+    expect(nested_schema.valid?({ nested: { field: 123 } })).to eq(true)
+    expect(nested_schema.valid?({ nested: { field: '123' } })).to eq(false)
+
+    # TODO:
+    #  - uncomment followwing spec
+    #  - need to fix nested schema structure reocniling bug (fails on source.key?(key) code)
+    # expect(nested_schema.valid?({ nested: 123 })).to eq(false)
+    # expect(nested_schema.valid?({ nested: {} })).to eq(false)
+
+    expect do
+      Class.new(SmartCore::Schema) do
+        schema do
           required(:mega).type(Object) # FAIL: dry-types requires Dry::Types::Type objects!
         end
       end


### PR DESCRIPTION
- alias was a hard-code based on the smart-core type system
- we need to interop with type object in order to use different type systems